### PR TITLE
fix(ansi): Fixed bug with unterminated sequences.

### DIFF
--- a/Filter System/RDAnsiFilter.m
+++ b/Filter System/RDAnsiFilter.m
@@ -700,13 +700,16 @@ static NSMutableArray *s_extendedColors = nil;
             
             if (!endRange.length) {
                 // unterminated ANSI!  Aiie!
-                NSRange eatMe = NSMakeRange(foundRange.location, length - foundRange.location);
-                NSAttributedString *holdover = [string attributedSubstringFromRange:eatMe];
-                // Munch these from our existing string, having stored them as holdover
-//                [string replaceCharactersInRange:eatMe withString:@""];
-                [_rdState setHoldover:holdover];
-                [string release];
-                [(NSMutableAttributedString *)input setAttributedString:result];
+                
+                // Hold over the current input for the next packet until we have
+                // don't have a split ANSI sequence. Outside of high latency
+                // between packets, this shouldn't take very long. Unfortunately,
+                // partial line parsing and attempted display sometimes causes
+                // visual artifacts.
+                [_rdState setHoldover:string];
+                NSMutableAttributedString *empty = [[NSMutableAttributedString alloc] initWithString:@"" attributes:[_rdState attributes]];
+                [(NSMutableAttributedString *)input setAttributedString:empty];
+                [empty release];
                 [result release];
                 return;
             }


### PR DESCRIPTION
This has been a minor yet persistent bug that I've been living with in Atlantis for some years.

On the MUD I play most often (Lost Souls), there's a few situations where very large ANSI-styled tables will sometimes result in truncated text due to Atlantis encountering an unterminated ANSI SGR sequence in the middle of a line due to a split packet.

Now having access to the source code, I can see that this results in the first part of the line leading up to the open ANSI sequence being formatted into a NSAttributedString, but this gets discarded when the holdover buffer is combined with the subsequent packet, resulting in only the second part of the affected line being displayed.

I changed the logic in RDAnsiFilter.m's filterInput method delay the parse of the affected packet until all ANSI sequences in the buffer are complete (typically the next one). unless the MUD output is so screwy that they *never* send another character that can be read as a sequence terminator.

I'm aware this change may cause slightly delays under high network latency conditions if there's a lot of time between packets, but I'm not sure how to prevent the misrendered text other than perhaps holding the generated NSAttributedString so we can rewrite it once there's enough data to write it all the way out the next newline.

An example can be demonstrated by using the code here: [TelnetTestWidget](https://github.com/hotspare/TelnetTestWidget), commit 4b58e03. It's a partial capture of an offending output from the MUD rolled up into a quick and dirty socket server that you can connect a MUD client to via port 9999 on localhost.

Atlantis 0.9.9.8 beta and below will misrender a couple of lines (check the right hand border of the displayed table, a few lines are foreshortened because the first part described above is missing). This change fixes the issue. For sake of comparison, TinTin++ 2.02.10 and Mudlet 4.11.2 display it correctly.